### PR TITLE
Use the major version number in repository-key path, not the version number

### DIFF
--- a/roles/container-engine/cri-o/tasks/cleanup.yaml
+++ b/roles/container-engine/cri-o/tasks/cleanup.yaml
@@ -2,7 +2,7 @@
 # TODO(cristicalin): drop this file after 2.21
 - name: CRI-O kubic repo name for debian os family
   set_fact:
-    crio_kubic_debian_repo_name: "{{ ((ansible_distribution == 'Ubuntu') | ternary('x', '')) ~ ansible_distribution ~ '_' ~ ansible_distribution_version }}"
+    crio_kubic_debian_repo_name: "{{ ((ansible_distribution == 'Ubuntu') | ternary('x', '')) ~ ansible_distribution ~ '_' ~ ansible_distribution_major_version }}"
   when: ansible_os_family == "Debian"
 
 - name: Remove legacy CRI-O kubic apt repo key


### PR DESCRIPTION
Currently we get a "404 Not Found" error:

"Failed to download key at https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/Debian_11.7/Release.key"


The correct path would be:

"https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/Debian_11/Release.key"

Using ansible_distribution_major_version ("11") instead of ansible_distribution_version ("11.7") will fix that issue.
